### PR TITLE
Move the group_by to the base URL

### DIFF
--- a/sync_octopus_tado.py
+++ b/sync_octopus_tado.py
@@ -8,12 +8,12 @@ def get_meter_reading_total_consumption(api_key, mprn, gas_serial_number):
     """
     Retrieves total gas consumption from the Octopus Energy API for the given gas meter point and serial number.
     """
-    url = f"https://api.octopus.energy/v1/gas-meter-points/{mprn}/meters/{gas_serial_number}/consumption/"
+    url = f"https://api.octopus.energy/v1/gas-meter-points/{mprn}/meters/{gas_serial_number}/consumption/?group_by=quarter"
     total_consumption = 0.0
 
     while url:
         response = requests.get(
-            url + "?group_by=quarter", auth=HTTPBasicAuth(api_key, "")
+            url, auth=HTTPBasicAuth(api_key, "")
         )
 
         if response.status_code == 200:


### PR DESCRIPTION
The URL returned by the API already contains the `group_by` so the second iteration seems to return a 404.

I came across this as I switched the grouping (locally) to 'day' and ran into this issue with this change fixed.